### PR TITLE
Isolation levelが環境依存となっており、複数同時購入時の在庫の制御ができていなかったので、トランザクション開始時にREAD_COMMITTEDを明示的に指定

### DIFF
--- a/src/Eccube/EventListener/TransactionListener.php
+++ b/src/Eccube/EventListener/TransactionListener.php
@@ -14,6 +14,7 @@
 namespace Eccube\EventListener;
 
 use Doctrine\Dbal\Connection;
+use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -80,6 +81,7 @@ class TransactionListener implements EventSubscriberInterface
             $Connection->connect();
         }
         $Connection->setAutoCommit(false);
+        $Connection->setTransactionIsolation(TransactionIsolationLevel::READ_COMMITTED);
         $this->em->beginTransaction();
         log_debug('Begin Transaction.');
     }


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
Isolation levelが環境依存となっており、複数同時購入時の在庫の制御ができていなかったので、トランザクション開始時にREAD_COMMITTEDを明示的に指定

## テスト（Test)
- MySQL使用時に在庫変更処理（StockReduceProcessor.php）時点でIsolation levelがREAD_COMMITTEDになっていることを確認
- 単一購入で在庫が問題なく減ることを確認

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更



